### PR TITLE
init/*.pl: modify perl scripts shebang

### DIFF
--- a/init/mergeLib.pl
+++ b/init/mergeLib.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This script is sourced from Brown (with slight modifications). It merges
 # several timing libraries into one.

--- a/init/removeDontUse.pl
+++ b/init/removeDontUse.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This script is sourced from Brown (with slight modifications). It merges
 # several timing libraries into one.


### PR DESCRIPTION
As there is no need to pass argument to perl, writing shebang in `#!/usr/bin/env perl` is more robust way. Some people maybe didn't put their `perl` executive file in `/usr/bin/perl` but still in their `$PATH`, and (maybe) default to use their shell interpreter as fallback.

![yakkhini@20230816195907](https://github.com/OSCPU/yosys-sta/assets/59007159/e6017f3a-5b98-4206-bb10-f96e71d3fc3b)

Maybe you should point out that perl is a dependence in README file.

More details in [this question on StackOverflow.](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash)

:)