### PR TITLE
Add docker support of iEDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 nangate45/
 result
 *.log
+config.mk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "iEDA"]
+	path = iEDA
+	url = https://gitee.com/oscc-project/iEDA.git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
+-include ./config.mk
+
 PROJ_PATH = $(shell pwd)
+DOCKER = docker
+ifeq ($(IEDA_DOCKER),1)
+	IEDA = $(DOCKER) run -it -v $(PROJ_PATH):$(PROJ_PATH) \
+		--rm iedaopensource/base:latest \
+		$(PROJ_PATH)/iEDA/bin/iEDA
+else
+	IEDA = LD_LIBRARY_PATH=$(PROJ_PATH)/bin/ $(PROJ_PATH)/bin/iEDA
+endif
 
 DESIGN ?= gcd
 SDC_FILE ?= $(PROJ_PATH)/example/gcd.sdc
@@ -15,6 +25,16 @@ TIMING_RPT = $(RESULT_DIR)/$(DESIGN).rpt
 
 init:
 	bash -c "$$(wget -O - https://ysyx.oscc.cc/slides/resources/scripts/init-yosys-sta.sh)"
+	echo "IEDA_DOCKER=0" > $(PROJ_PATH)/config.mk
+
+init-docker: init
+	-rm -rf bin/
+	git submodule init
+	git submodule update
+	$(DOCKER) run -it -v $(PROJ_PATH):$(PROJ_PATH) \
+		--rm iedaopensource/base:latest \
+		bash $(PROJ_PATH)/iEDA/build.sh
+	echo "IEDA_DOCKER=1" > $(PROJ_PATH)/config.mk
 
 syn: $(NETLIST_SYN_V)
 $(NETLIST_SYN_V): $(RTL_FILES) $(SCRIPT_DIR)/yosys.tcl
@@ -23,17 +43,17 @@ $(NETLIST_SYN_V): $(RTL_FILES) $(SCRIPT_DIR)/yosys.tcl
 
 def: $(SYN_DEF)
 $(SYN_DEF): $(SCRIPT_DIR)/def.tcl $(NETLIST_SYN_V)
-	LD_LIBRARY_PATH=bin/ ./bin/iEDA $^ $(DESIGN) $@ | tee $(RESULT_DIR)/gen-def.log
+	$(IEDA) $^ $(DESIGN) $@ | tee $(RESULT_DIR)/gen-def.log
 
 fix-fanout: $(NETLIST_FIXED_V)
 $(NETLIST_FIXED_V): $(SCRIPT_DIR)/fix-fanout.tcl $(SDC_FILE) $(SYN_DEF)
-	LD_LIBRARY_PATH=bin/ ./bin/iEDA -script $^ $@ 2>&1 | tee $(RESULT_DIR)/fix-fanout.log
+	$(IEDA) -script $^ $@ 2>&1 | tee $(RESULT_DIR)/fix-fanout.log
 
 sta: $(TIMING_RPT)
 $(TIMING_RPT): $(SCRIPT_DIR)/sta.tcl $(SDC_FILE) $(NETLIST_FIXED_V)
-	LD_LIBRARY_PATH=bin/ ./bin/iEDA -script $^ $(DESIGN) 2>&1 | tee $(RESULT_DIR)/sta.log
+	$(IEDA) -script $^ $(DESIGN) 2>&1 | tee $(RESULT_DIR)/sta.log
 
 clean:
 	-rm -rf result/
 
-.PHONY: init syn def fix-fanout sta clean
+.PHONY: init init-docker syn def fix-fanout sta clean

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@
 ```shell
 apt install yosys
 apt install libunwind-dev libyaml-cpp-dev libgomp1 libtcl8.6 # iEDA的依赖库
-make init
+make init # 下载预编译的iEDA和nangate45工艺库
+```
+
+如果预编译的iEDA不能正常运行，或者希望使用最新版本的iEDA，可以在Docker中编译和运行iEDA.
+
+```shell
+make init-docker
 ```
 
 ## 评估样例设计


### PR DESCRIPTION
Pre-compiled iEDA may not run on different distributions (e.g. dynamic link library issues). [iedaopensource/base](https://hub.docker.com/r/iedaopensource/base) can be used to compile and run the latest version of iEDA. [iedaopensource/release](https://hub.docker.com/r/iedaopensource/release) may be out-of-date.